### PR TITLE
Fix logic error in StringSource checkImports function

### DIFF
--- a/src/com/bergi9/less/v8/io/StringSource.java
+++ b/src/com/bergi9/less/v8/io/StringSource.java
@@ -19,7 +19,7 @@ public class StringSource extends AbstractSource
 	
 	private void checkImports() throws IOException
 	{
-		if(content.contains("@import") && (path != null || path.isEmpty()))
+		if(content.contains("@import") && (path == null || path.isEmpty()))
 		{
 			throw new IOException("Path cannot be null or empty if there are imports");
 		}


### PR DESCRIPTION
Trying to use @imports with StringSource was failing due to a logic error in the checkImports() method, I believe this fixes the issue.